### PR TITLE
Add unit test for issue #3

### DIFF
--- a/openclean/operator/base.py
+++ b/openclean/operator/base.py
@@ -25,6 +25,15 @@ can output a stage state object.
 """
 
 from abc import ABCMeta, abstractmethod
+from typing import List, Union
+
+
+"""Type alias definition for parameters and return values of different
+operators in openclean.
+"""
+ColumnRef = Union[int, str]
+Columns = Union[ColumnRef, List[Union[ColumnRef]]]
+Names = Union[str, List[str]]
 
 
 class PipelineStage(metaclass=ABCMeta):

--- a/openclean/operator/transform/select.py
+++ b/openclean/operator/transform/select.py
@@ -9,14 +9,21 @@
 openclean.
 """
 
+from typing import List, Optional, Union
+
+import pandas as pd
+
 from openclean.data.column import Column
 from openclean.data.select import as_list, select_clause, select_by_id
-from openclean.operator.base import DataFrameTransformer
+from openclean.operator.base import Columns, DataFrameTransformer, Names
 
 
 # -- Functions ----------------------------------------------------------------
 
-def filter_columns(df, colids, names=None):
+def filter_columns(
+    df: pd.DataFrame, colids: Union[int, List[int]],
+    names: Optional[Names] = None
+) -> pd.DataFrame:
     """Filter columns by their identifier. Returns a data frame that contains
     the columns whose identifier are included in the given list. Raises a
     ValueError if the column identifier list contains values that do not
@@ -44,7 +51,9 @@ def filter_columns(df, colids, names=None):
     return Select(columns=columns, names=names).transform(df)
 
 
-def select(df, columns, names=None):
+def select(
+    df: pd.DataFrame, columns: Columns, names: Optional[Names] = None
+) -> pd.DataFrame:
     """Projection operator that selects a list of columns from a data frame.
     Returns a data frame that contains only thoses columns that are included in
     the given select clause. The optional list of names allows to rename the
@@ -78,7 +87,7 @@ class Select(DataFrameTransformer):
     The output is a data frame that contains all rows from an input data frame
     but only those columns that are included in a given select clause.
     """
-    def __init__(self, columns, names=None):
+    def __init__(self, columns: Columns, names: Optional[Names] = None):
         """Initialize the list of columns that are being selected. The optional
         list of names allows to rename columns. If the list of names is given
         it has to be of the same length as the list of columns.
@@ -105,7 +114,7 @@ class Select(DataFrameTransformer):
         else:
             self.names = None
 
-    def transform(self, df):
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
         """Return a data frame that contains all rows but only those columns
         from the given input data frame that are included in the select clause.
 

--- a/openclean/vizual.py
+++ b/openclean/vizual.py
@@ -5,7 +5,7 @@
 # openclean is released under the Revised BSD License. See file LICENSE for
 # full license details.
 
-"""Collection of openclean operators that represent (or are similar) to VizUAL
+"""Collection of openclean operators that represent (or are similar to) VizUAL
 operators.
 """
 

--- a/tests/operator/transform/test_op_select.py
+++ b/tests/operator/transform/test_op_select.py
@@ -91,3 +91,30 @@ def test_select_with_rename(employees):
     # Ensure that all columns are of type Columns and not strings
     for col in d1.columns:
         assert isinstance(col, Column)
+
+
+def test_select_with_shuffle(agencies):
+    """Test selecting columns and changing their order in the resulting data
+    frame (issue #3).
+    """
+    # Select columns in original order.
+    df = select(agencies, ['borough', 'state'])
+    assert list(df.columns) == ['borough', 'state']
+    # Select columns in different order than in the original data frame.
+    df = select(agencies, ['state', 'borough'])
+    assert list(df.columns) == ['state', 'borough']
+    states = set(df['state'].value_counts().index)
+    assert len(states) == 2
+    assert 'NJ' in states
+    assert 'NY' in states
+    # Shuffle columns with renaming.
+    df = select(
+        agencies,
+        columns=['state', 'borough', 'agency'],
+        names=['US State', 'Boro', 'Agency Name']
+    )
+    assert list(df.columns) == ['US State', 'Boro', 'Agency Name']
+    states = set(df['US State'].value_counts().index)
+    assert len(states) == 2
+    assert 'NJ' in states
+    assert 'NY' in states


### PR DESCRIPTION
This PR addresses issue #3. The issue did not occur any longer in the latest version of the code in the main branch. I added a unit test that asserts that the select operator returns a data frame where columns are in order as specified in the columns list of the operator.