### PR TITLE
Base openclean.cluster.base.Cluster of collections.Counter

### DIFF
--- a/examples/notebooks/parking-violations/Parking Violations - Key Collision Clustering for Street Names.ipynb
+++ b/examples/notebooks/parking-violations/Parking Violations - Key Collision Clustering for Street Names.ipynb
@@ -294,7 +294,7 @@
     "\n",
     "def print_cluster(cnumber, cluster):\n",
     "    print('Cluster {} (of size {})\\n'.format(cnumber, len(cluster)))\n",
-    "    for val, count in cluster:\n",
+    "    for val, count in cluster.items():\n",
     "        print('{} ({})'.format(val, count))\n",
     "    print('\\nSuggested value: {}\\n\\n'.format(cluster.suggestion()))\n",
     "    \n",
@@ -1361,7 +1361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/tests/cluster/test_cluster.py
+++ b/tests/cluster/test_cluster.py
@@ -18,23 +18,16 @@ def test_add_cluster_elements():
     for value in list('acbaabbac'):  # 4xa, 3xb, 2xc
         c.add(value)
     assert len(c) == 3
-    assert c[0] == 'a'
-    assert c[1] == 'c'
-    assert c[2] == 'b'
-    with pytest.raises(KeyError):
-        c[3]
-    counts = {value: count for value, count in c}
-    assert counts['a'] == 4
-    assert counts['b'] == 3
-    assert counts['c'] == 2
+    assert c['a'] == 4
+    assert c['b'] == 3
+    assert c['c'] == 2
 
 
 def test_cluster_from_counter():
     """Test adding to a cluster with frequency count values."""
     c = Cluster().add('a', count=5).add('b', count=10).add('a', count=6)
-    counts = {value: count for value, count in c}
-    assert counts['a'] == 11
-    assert counts['b'] == 10
+    assert c['a'] == 11
+    assert c['b'] == 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR simplifies the implementation of `openclean.cluster.base.Cluster`. Clusters are now sub-classes of `collections.Counter` (#98).