### PR TITLE
Use appdirs.user_cache_dir as parent for the openclean base directory

### DIFF
--- a/openclean/config.py
+++ b/openclean/config.py
@@ -9,7 +9,7 @@
 are maintained in environment variables.
 """
 
-from pathlib import Path
+from appdirs import user_cache_dir
 
 import os
 
@@ -30,7 +30,7 @@ def DATADIR() -> str:
     -------
     string
     """
-    default_value = os.path.join(str(Path.home()), '.openclean', 'data')
+    default_value = os.path.join(user_cache_dir(appname=__name__.split('.')[0]), 'data')
     return os.environ.get(ENV_DATA_DIR, default_value)
 
 
@@ -41,7 +41,7 @@ def MASTERDATADIR() -> str:
     -------
     string
     """
-    default_value = os.path.join(str(Path.home()), '.openclean', 'masterdata')
+    default_value = os.path.join(user_cache_dir(appname=__name__.split('.')[0]), 'masterdata')
     return os.environ.get(ENV_MASTERDATA_DIR, default_value)
 
 

--- a/openclean/engine/store/function.py
+++ b/openclean/engine/store/function.py
@@ -23,7 +23,7 @@ import openclean.config as config
 class FunctionRepository(DefaultObjectStore):
     """Object store for library functions. Persists all user-defined functions
     on disk using a file system data store. The files are stored under the
-    openclean home directory if no nbase directory is specififed.
+    openclean home directory if no base directory is specififed.
     """
     def __init__(
         self, basedir: Optional[str] = None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 future
+appdirs>=1.4.4
 python-dateutil
 requests
 dill

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'future',
+    'appdirs>=1.4.4',
     'python-dateutil',
     'dill',
     'requests',


### PR DESCRIPTION
This PR includes the following change:

* Use appdirs.user_cache_dir as parent for the openclean base directory

Closes #104 