### PR TITLE
Dataset history patch

### DIFF
--- a/examples/notebooks/engine/Openclean Engine - Datastore.ipynb
+++ b/examples/notebooks/engine/Openclean Engine - Datastore.ipynb
@@ -1266,9 +1266,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "d863328a3da645f5b304e51414e8897d {'optype': 'sample', 'columns': None, 'arguments': [{'name': 'n', 'value': 10}, {'name': 'randomState', 'value': 43}]}\n",
-      "a0440be6e67641639342cdbdf4ea7e78 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n",
-      "3c9336090c444c86a4a28b51855456e3 {'optype': 'update', 'columns': ['City'], 'name': 'zigzag'}\n"
+      "0 {'optype': 'sample', 'columns': None, 'arguments': [{'name': 'n', 'value': 10}, {'name': 'randomState', 'value': 43}]}\n",
+      "1 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n",
+      "2 {'optype': 'update', 'columns': ['City'], 'name': 'zigzag'}\n"
      ]
     }
    ],
@@ -1280,8 +1280,8 @@
     "\n",
     "snapshots = list()\n",
     "for op in db.dataset('bidders').log():\n",
-    "    print('{} {}'.format(op.identifier, op.descriptor))\n",
-    "    snapshots.append(op.identifier)"
+    "    print('{} {}'.format(op.version, op.descriptor))\n",
+    "    snapshots.append(op.version)"
    ]
   },
   {
@@ -1653,8 +1653,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "d863328a3da645f5b304e51414e8897d {'optype': 'sample', 'columns': None, 'arguments': [{'name': 'n', 'value': 10}, {'name': 'randomState', 'value': 43}]}\n",
-      "a0440be6e67641639342cdbdf4ea7e78 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n"
+      "0 {'optype': 'sample', 'columns': None, 'arguments': [{'name': 'n', 'value': 10}, {'name': 'randomState', 'value': 43}]}\n",
+      "1 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n"
      ]
     }
    ],
@@ -1662,8 +1662,8 @@
     "# Show remaining operations in the current dataset log.\n",
     "\n",
     "for op in db.dataset('bidders').log():\n",
-    "    print('{} {}'.format(op.identifier, op.descriptor))\n",
-    "    snapshots.append(op.identifier)"
+    "    print('{} {}'.format(op.version, op.descriptor))\n",
+    "    snapshots.append(op.version)"
    ]
   },
   {
@@ -1868,10 +1868,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'optype': 'load', 'columns': None}\n",
-      "{'optype': 'commit', 'columns': None}\n",
-      "{'optype': 'update', 'columns': ['Bidders Name'], 'name': 'lower'}\n",
-      "{'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n"
+      "0 {'optype': 'load', 'columns': None}\n",
+      "1 {'optype': 'commit', 'columns': None}\n",
+      "2 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'lower'}\n",
+      "3 {'optype': 'update', 'columns': ['Bidders Name'], 'name': 'capitalize'}\n"
      ]
     }
    ],
@@ -1879,15 +1879,15 @@
     "# Show operations in the resulting dataset log.\n",
     "\n",
     "for op in db.dataset('bidders').log():\n",
-    "    print(op.descriptor)"
+    "    print(op.version, op.descriptor)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "PyCharm (openclean-core)",
    "language": "python",
-   "name": "python3"
+   "name": "pycharm-c6d12a8"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1899,7 +1899,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/openclean/engine/dataset.py
+++ b/openclean/engine/dataset.py
@@ -68,9 +68,10 @@ class DatasetHandle(metaclass=ABCMeta):
         """
         if identifier is None:
             return self.store.checkout()
-        for op in self._log:
+        for i, op in enumerate(self._log):
             if op.identifier == identifier:
-                return self.store.checkout(version=op.version)
+                # use versions for samples (uncommitted datasets) and operation sequence for full datasets (committed)
+                return self.store.checkout(version=op.version) if not op.is_committed else self.store.checkout(version=i)
         raise KeyError("unknown log entry '{}'".format(identifier))
 
     def commit(self, df: pd.DataFrame, action: Optional[OpHandle] = None) -> pd.DataFrame:

--- a/tests/engine/test_openclean_engine.py
+++ b/tests/engine/test_openclean_engine.py
@@ -32,7 +32,7 @@ def test_recreate_engine(cached, dataset, tmpdir):
 
 
 def test_full_df_checkout(dataset, tmpdir):
-    """Test if a full dataset rollback is possible"""
+    """Test if a full dataset checkout is possible"""
     db = DB(basedir=str(tmpdir), create=True)
     # Create two datasets with a single snapshot.
     df = db.create(source=dataset, name='test')
@@ -43,9 +43,9 @@ def test_full_df_checkout(dataset, tmpdir):
     db.commit(name='test', df=df1)
     snapshots = db.dataset('test').log()
 
-    df = db.dataset('test').checkout(identifier=snapshots[1].identifier)
+    df = db.dataset('test').checkout(version=snapshots[1].version)
     assert list(df['A']) == list(df1['A'])
 
-    df = db.dataset('test').checkout(identifier=snapshots[0].identifier)
+    df = db.dataset('test').checkout(version=snapshots[0].version)
     assert list(df['A']) == list(dataset['A'])
 

--- a/tests/engine/test_openclean_engine.py
+++ b/tests/engine/test_openclean_engine.py
@@ -29,3 +29,23 @@ def test_recreate_engine(cached, dataset, tmpdir):
     assert df.shape == (2, 3)
     df = engine.checkout(name='More Data')
     assert df.shape == (1, 3)
+
+
+def test_full_df_checkout(dataset, tmpdir):
+    """Test if a full dataset rollback is possible"""
+    db = DB(basedir=str(tmpdir), create=True)
+    # Create two datasets with a single snapshot.
+    df = db.create(source=dataset, name='test')
+    assert df.shape == (2, 3)
+
+    df1 = df.copy(deep=True)
+    df1['A'] = df1['A'] + 1
+    db.commit(name='test', df=df1)
+    snapshots = db.dataset('test').log()
+
+    df = db.dataset('test').checkout(identifier=snapshots[1].identifier)
+    assert list(df['A']) == list(df1['A'])
+
+    df = db.dataset('test').checkout(identifier=snapshots[0].identifier)
+    assert list(df['A']) == list(dataset['A'])
+


### PR DESCRIPTION
Addresses #107 by removing the differentiation between LogEntry unique identifiers and version numbers.