### PR TITLE
pandas type inference inside operators switched off

### DIFF
--- a/openclean/data/load.py
+++ b/openclean/data/load.py
@@ -72,4 +72,4 @@ def dataset(
                 row = [typecast.cast(v) for v in row]
             data.append(row)
             index.append(rowid)
-        return pd.DataFrame(data=data, columns=file.columns, index=index)
+        return pd.DataFrame(data=data, columns=file.columns, index=index, dtype=object)

--- a/openclean/operator/stream/collector.py
+++ b/openclean/operator/stream/collector.py
@@ -91,6 +91,7 @@ class DataFrame(StreamConsumer, StreamProcessor):
         self.columns = columns
         self.data = list()
         self.index = list()
+        self.dtypes = object
 
     def close(self) -> pd.DataFrame:
         """Closing the consumer yields the data frame with the collected rows.
@@ -102,7 +103,8 @@ class DataFrame(StreamConsumer, StreamProcessor):
         return pd.DataFrame(
             data=self.data,
             columns=self.columns,
-            index=self.index
+            index=self.index,
+            dtype=self.dtypes
         )
 
     def consume(self, rowid: int, row: List):

--- a/openclean/operator/transform/apply.py
+++ b/openclean/operator/transform/apply.py
@@ -100,4 +100,4 @@ class Apply(DataFrameTransformer):
             for f, colidx in functions:
                 values[colidx] = f(values[colidx])
             data.append(values)
-        return pd.DataFrame(data=data, index=df.index, columns=df.columns)
+        return pd.DataFrame(data=data, index=df.index, columns=df.columns, dtype=object)

--- a/openclean/operator/transform/insert.py
+++ b/openclean/operator/transform/insert.py
@@ -254,7 +254,7 @@ class InsCol(StreamProcessor, DataFrameTransformer):
         # Insert the column names into the data frame schema.
         columns = list(df.columns)
         columns = columns[:inspos] + self.names + columns[inspos:]
-        return pd.DataFrame(data=data, index=df.index, columns=columns)
+        return pd.DataFrame(data=data, index=df.index, columns=columns, dtype=object)
 
 
 class InsRow(DataFrameTransformer):
@@ -350,4 +350,4 @@ class InsRow(DataFrameTransformer):
         for i in range(inspos, len(df.index)):
             data.append(list(df.iloc[i]))
             index.append(df.index[i])
-        return pd.DataFrame(data=data, index=index, columns=df.columns)
+        return pd.DataFrame(data=data, index=index, columns=df.columns, dtype=object)

--- a/openclean/operator/transform/update.py
+++ b/openclean/operator/transform/update.py
@@ -195,8 +195,7 @@ class Update(StreamProcessor, DataFrameTransformer):
 
         data = df.to_numpy(copy=True)
         data[:, colidxs] = updates
-
-        return pd.DataFrame(data=data, index=df.index, columns=df.columns)
+        return pd.DataFrame(data=data, index=df.index, columns=df.columns, dtype=object)
 
 
 # -- Helper functions ---------------------------------------------------------

--- a/tests/pipeline/test_stream_to_df.py
+++ b/tests/pipeline/test_stream_to_df.py
@@ -18,6 +18,6 @@ from openclean.pipeline import stream
 def test_generate_df_from_stream():
     """Test creating a data frame from the rows in a stream."""
     data = [[1, 2, 3], [3, 4, 5], [5, 6, 7]]
-    df = pd.DataFrame(data=data, columns=['A', 'B', 'C'])
+    df = pd.DataFrame(data=data, columns=['A', 'B', 'C'], dtype=object) # switching off pandas type detection
     ds = stream(df).to_df()
     assert_frame_equal(df, ds)


### PR DESCRIPTION
pandas type inference inside operators switched off as discussed for #59 