### PR TITLE
Dev 0.1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2020 New York University. 
+Copyright (C) 2018-2021 New York University. 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,12 @@ About
 
 While a large number of different tools and techniques have previously been developed for profiling and cleaning data, one main issue that we see with these tools is the lack of access to them in a single (unified) framework. Existing tools may be implemented in different programming languages and require significant effort to install and interface with. In other cases, promising data cleaning methods have been published in the scientific literature but there is no suitable codebase available for them. We believe that the lack of seamless access to existing work is a major contributor to why data preparation is so time consuming.
 
-The goal of **openclean** goal is to bring together data cleaning tools in a single environment that is easy and intuitive to use for a data scientist. **openclean** allows users to compose and execute cleaning pipelines that are built using a variety of different tools. We aim for **openclean** to be flexible and extensible to allow easy integration of new functionality. To this end, we define a set of primitives and API’s for the different types of operators (actors) in **openclean** pipelines.
+The goal of **openclean** is to bring together data cleaning tools in a single environment that is easy and intuitive to use for a data scientist. **openclean** allows users to compose and execute cleaning pipelines that are built using a variety of different tools. We aim for **openclean** to be flexible and extensible to allow easy integration of new functionality. To this end, we define a set of primitives and API’s for the different types of operators (actors) in **openclean** pipelines.
 
 
 Features
 ========
-openclean has many features that make the Data munging experience straightforward. It shines particularly in these areas:
+openclean has many features that make the data wrangling experience straightforward. It shines particularly in these areas:
 
 Data Profiling
 --------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # openclean - Data Cleaning for Python - Changelog
 
-### 0.1.0 - 2020-12-23
+### 0.1.0 - 2021-02-23
 
 * Initial release.
+
+
+### 0.1.1 - 2021-03-02
+
+* Bump `flowserv-core` dependency to version `0.8.0` for better support of running applications that are not implemented in Python.
+* Introduce environment variable *OPENCLEAN_WORKERS* to configure workers for `flowserv-core`.
+* Replace environment variables *OPENCLEAN_METADATA_DIR* with *OPENCLEAN_DATADIR*.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ The goal of openclean goal is to bring together data cleaning tools in a single 
     source/provenance
     source/examples
     source/extras
+    source/configuration
     source/contribute
     source/faq
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,27 @@
+.. _config-ref:
+
+Configuration
+=============
+openclean defines several environment variables that can be used to configure the behavior of different parts of the package.
+
+
+Data Storage
+------------
+
+Some components of the openclean package store external data files. These files will be stored in sub-folders of a base directory that is specified by the environment variable *OPENCLEAN_DATADIR*. By default, the folder ``openclean/data`` user's cache directory is used as the base directory.
+
+
+Multi-Threading
+---------------
+
+Several tasks in openclean lend themselves well to being run using multiple threads (e.g., key collision clustering using :class:KeyCollision). If the environment variable *OPENCLEAN_THREADS* is set to a positive integer value, it defies the number of parallel treads that are used by default. If the variable is not set (or set to ``1``) a single tread is used.
+
+
+Configuration for Workers for External Processes
+------------------------------------------------
+
+openclean integrates data cleaning and data profiling tools that are implemented in programming languages other than Python and that are executed as external processes. For this purpose, openclean depends on the `flowServ package <https://github.com/scailfin/flowserv-core>`_ that supports execution of sequential workflows (data processing pipelines) in different environments. The environments that are currently supported either use the Python ``subprocess`` package of `Docker <https://www.docker.com>`_.
+
+Workers for external process are configured using configuration files that define the type of execution engine that is used for different tasks (refer to the `flowServ documentation for file formats and configuration options <https://flowserv-core.readthedocs.io/en/latest/source/configuration.html#serial-engine-workers>`_).
+
+openclean allows the user to override default worker configurations using the environment variable *OPENCLEAN_WORKERS*. If the variable refers to an existing configuration file, the definitions in that file will override default configurations.

--- a/examples/notebooks/Country Names.ipynb
+++ b/examples/notebooks/Country Names.ipynb
@@ -23,14 +23,9 @@
    "outputs": [],
    "source": [
     "# Create a new local archive for the countries dataset. All archive data will be stored in\n",
-    "# a sub-folder of the users home directory. Set the environment variable 'OPENCLEAN_MASTERDATA_DIR'\n",
-    "# to change the default behaviour.\n",
+    "# a sub-folder 'data'.\n",
     "\n",
-    "import os\n",
-    "\n",
-    "from openclean.config import ENV_MASTERDATA_DIR\n",
-    "\n",
-    "os.environ[ENV_MASTERDATA_DIR] = './data'"
+    "datadir = './data'"
    ]
   },
   {
@@ -53,7 +48,7 @@
     {
      "data": {
       "text/plain": [
-       "<Snapshot (version=0 description='' at=2021-01-11 15:36:03.674996-05:00)>"
+       "<Snapshot (version=0 description='' at=2021-02-26 11:06:39.568311-05:00)>"
       ]
      },
      "execution_count": 2,
@@ -64,11 +59,13 @@
    "source": [
     "# Download the current listing of country names in the world.\n",
     "\n",
-    "from openclean.data.source.restcountries import RestcountriesRepository, COUNTRIES\n",
+    "from openclean.data.refdata import RefStore\n",
     "\n",
-    "import openclean.data.masterdata as masterdata\n",
+    "import openclean.data.archive as masterdata\n",
     "\n",
-    "countries = RestcountriesRepository().dataset(COUNTRIES).load()\n",
+    "refstore = RefStore(basedir=datadir)\n",
+    "refstore.download('restcountries.eu')\n",
+    "countries = refstore.load('restcountries.eu').df()\n",
     "\n",
     "print(countries.head())\n",
     "\n",
@@ -386,7 +383,7 @@
        "      <td>Korea (Republic of)</td>\n",
        "      <td>NaN</td>\n",
        "      <td>rank</td>\n",
-       "      <td>1</td>\n",
+       "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -395,7 +392,7 @@
        "      <td>Denmark</td>\n",
        "      <td>NaN</td>\n",
        "      <td>rank</td>\n",
-       "      <td>2</td>\n",
+       "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -404,7 +401,7 @@
        "      <td>Iceland</td>\n",
        "      <td>NaN</td>\n",
        "      <td>rank</td>\n",
-       "      <td>3</td>\n",
+       "      <td>3.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -413,7 +410,7 @@
        "      <td>United Kingdom of Great Britain and Northern I...</td>\n",
        "      <td>NaN</td>\n",
        "      <td>rank</td>\n",
-       "      <td>4</td>\n",
+       "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -422,7 +419,7 @@
        "      <td>Sweden</td>\n",
        "      <td>NaN</td>\n",
        "      <td>rank</td>\n",
-       "      <td>5</td>\n",
+       "      <td>5.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -437,11 +434,11 @@
        "4  2015        SWE                                             Sweden   \n",
        "\n",
        "  sub_index value_type value  \n",
-       "0       NaN       rank     1  \n",
-       "1       NaN       rank     2  \n",
-       "2       NaN       rank     3  \n",
-       "3       NaN       rank     4  \n",
-       "4       NaN       rank     5  "
+       "0       NaN       rank   1.0  \n",
+       "1       NaN       rank   2.0  \n",
+       "2       NaN       rank   3.0  \n",
+       "3       NaN       rank   4.0  \n",
+       "4       NaN       rank   5.0  "
       ]
      },
      "execution_count": 8,
@@ -470,15 +467,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   },
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/examples/notebooks/Masterdata.ipynb
+++ b/examples/notebooks/Masterdata.ipynb
@@ -20,10 +20,10 @@
     "\n",
     "import os\n",
     "\n",
-    "from openclean.config import ENV_MASTERDATA_DIR\n",
+    "from openclean.config import ENV_DATA_DIR\n",
     "from refdata.config import ENV_BASEDIR\n",
     "\n",
-    "os.environ[ENV_MASTERDATA_DIR] = './data/archives'\n",
+    "os.environ[ENV_DATA_DIR] = './data/archives'\n",
     "os.environ[ENV_BASEDIR] = './data/refdata'"
    ]
   },
@@ -195,7 +195,7 @@
     {
      "data": {
       "text/plain": [
-       "<Snapshot (version=0 description='' at=2021-02-16 17:28:18.211195-05:00)>"
+       "<Snapshot (version=0 description='' at=2021-02-26 11:07:34.902079-05:00)>"
       ]
      },
      "execution_count": 7,
@@ -387,7 +387,7 @@
     {
      "data": {
       "text/plain": [
-       "<Snapshot (version=1 description='' at=2021-02-16 17:28:18.359359-05:00)>"
+       "<Snapshot (version=1 description='' at=2021-02-26 11:07:35.063135-05:00)>"
       ]
      },
      "execution_count": 10,
@@ -475,8 +475,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<Snapshot (version=0 description='' at=2021-02-16 17:28:18.211195-05:00)>\n",
-      "<Snapshot (version=1 description='' at=2021-02-16 17:28:18.359359-05:00)>\n"
+      "<Snapshot (version=0 description='' at=2021-02-26 11:07:34.902079-05:00)>\n",
+      "<Snapshot (version=1 description='' at=2021-02-26 11:07:35.063135-05:00)>\n"
      ]
     }
    ],
@@ -671,10 +671,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
-    "source": [],
     "metadata": {
      "collapsed": false
-    }
+    },
+    "source": []
    }
   }
  },

--- a/openclean/config.py
+++ b/openclean/config.py
@@ -10,8 +10,12 @@ are maintained in environment variables.
 """
 
 from appdirs import user_cache_dir
+from flowserv.controller.serial.worker.factory import WorkerFactory, convert_config
+from typing import List, Optional
 
+import json
 import os
+import yaml
 
 
 """Environment variables that maintain configuration parameters."""
@@ -21,6 +25,8 @@ ENV_DATA_DIR = 'OPENCLEAN_DATA_DIR'
 ENV_MASTERDATA_DIR = 'OPENCLEAN_MASTERDATA_DIR'
 # Number of parallel threads to use.
 ENV_THREADS = 'OPENCLEAN_THREADS'
+# Configuration file containing the configuration for flowServ workers.
+ENV_WORKERS = 'OPENCLEAN_WORKERS'
 
 
 def DATADIR() -> str:
@@ -60,3 +66,61 @@ def THREADS() -> int:
     except ValueError:
         threads = 1
     return 1 if threads < 1 else threads
+
+
+def WORKERS(var: Optional[str] = None) -> WorkerFactory:
+    """Create a worker factory for serial workflow execution from a configuration
+    file.
+
+    By default, the configuration is read from the file that is referenced by
+    the environment variable `OPENCLEAN_WORKERS`. If the optional environment
+    variable `var` is given and references an existing file, the configurations
+    from that file will override the default configuration.
+
+    Parameters
+    ----------
+    var: string, default=None
+        Optional name for an environment variable that references a file with
+        flowServ worker configurations that will override the values in the
+        default configuration.
+
+    Returns
+    -------
+    flowserv.controller.serial.worker.factory.WorkerFactory
+    """
+    worker_conf = convert_config(read_list(os.environ.get(ENV_WORKERS)))
+    if var:
+        worker_conf.update(convert_config(read_list(os.environ.get(var))))
+    return WorkerFactory(config=worker_conf)
+
+
+# -- Helper Functions ---------------------------------------------------------
+
+def read_list(filename: str) -> List:
+    """Read a list object from a given file.
+
+    The file type is guessed from the file suffix. If the file ends with '.json'
+    it is assumed to be in Json format. Otherwise, Yaml format is assumed by
+    default.
+
+    If the filename is None or empty an empty list is returned.
+
+    Parameters
+    ----------
+    filename: string
+        Path to file on disk.
+
+    Returns
+    -------
+    list
+    """
+    # Return an empty list of the filename is not given
+    if not filename:
+        return list()
+    # Guess the file type from the name suffix. By default, Yaml is assumed.
+    if filename.endswith('.json'):
+        with open(filename, 'r') as f:
+            return json.load(f)
+    else:
+        with open(filename, 'r') as f:
+            return yaml.load(f.read(), Loader=yaml.FullLoader)

--- a/openclean/config.py
+++ b/openclean/config.py
@@ -11,7 +11,7 @@ are maintained in environment variables.
 
 from appdirs import user_cache_dir
 from flowserv.controller.worker.factory import WorkerFactory, convert_config
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import json
 import os
@@ -55,7 +55,7 @@ def THREADS() -> int:
     return 1 if threads < 1 else threads
 
 
-def WORKERS(var: Optional[str] = None) -> WorkerFactory:
+def WORKERS(var: Optional[str] = None, env: Optional[Dict] = None) -> WorkerFactory:
     """Create a worker factory for serial workflow execution from a configuration
     file.
 
@@ -70,14 +70,20 @@ def WORKERS(var: Optional[str] = None) -> WorkerFactory:
         Optional name for an environment variable that references a file with
         flowServ worker configurations that will override the values in the
         default configuration.
+    env: dict, default=None
+        Optional environment variables that override the system-wide
+        settings., defualt=None
 
     Returns
     -------
     flowserv.controller.serial.worker.factory.WorkerFactory
     """
-    worker_conf = convert_config(read_list(os.environ.get(ENV_WORKERS)))
+    vars = dict(os.environ)
+    if env:
+        vars.update(env)
+    worker_conf = convert_config(read_list(vars.get(ENV_WORKERS)))
     if var:
-        worker_conf.update(convert_config(read_list(os.environ.get(var))))
+        worker_conf.update(convert_config(read_list(vars.get(var))))
     return WorkerFactory(config=worker_conf)
 
 

--- a/openclean/config.py
+++ b/openclean/config.py
@@ -10,7 +10,7 @@ are maintained in environment variables.
 """
 
 from appdirs import user_cache_dir
-from flowserv.controller.serial.worker.factory import WorkerFactory, convert_config
+from flowserv.controller.worker.factory import WorkerFactory, convert_config
 from typing import List, Optional
 
 import json

--- a/openclean/config.py
+++ b/openclean/config.py
@@ -20,9 +20,7 @@ import yaml
 
 """Environment variables that maintain configuration parameters."""
 # Directory for raw data files.
-ENV_DATA_DIR = 'OPENCLEAN_DATA_DIR'
-# Download directory
-ENV_MASTERDATA_DIR = 'OPENCLEAN_MASTERDATA_DIR'
+ENV_DATA_DIR = 'OPENCLEAN_DATADIR'
 # Number of parallel threads to use.
 ENV_THREADS = 'OPENCLEAN_THREADS'
 # Configuration file containing the configuration for flowServ workers.
@@ -38,17 +36,6 @@ def DATADIR() -> str:
     """
     default_value = os.path.join(user_cache_dir(appname=__name__.split('.')[0]), 'data')
     return os.environ.get(ENV_DATA_DIR, default_value)
-
-
-def MASTERDATADIR() -> str:
-    """Get directory where master data repositories are maintained.
-
-    Returns
-    -------
-    string
-    """
-    default_value = os.path.join(user_cache_dir(appname=__name__.split('.')[0]), 'masterdata')
-    return os.environ.get(ENV_MASTERDATA_DIR, default_value)
 
 
 def THREADS() -> int:

--- a/openclean/data/archive/__init__.py
+++ b/openclean/data/archive/__init__.py
@@ -9,8 +9,9 @@
 managing archives of datasets.
 """
 
-
 from typing import List, Optional
+
+import os
 
 from histore import PersistentArchiveManager
 from histore.archive.base import Archive
@@ -113,4 +114,4 @@ def manager() -> PersistentArchiveManager:
     -------
     histore.archive.manager.base.ArchiveManager
     """
-    return PersistentArchiveManager(basedir=config.MASTERDATADIR())
+    return PersistentArchiveManager(basedir=os.path.join(config.DATADIR(), 'archives'))

--- a/openclean/profiling/anomalies/pattern.py
+++ b/openclean/profiling/anomalies/pattern.py
@@ -73,8 +73,7 @@ class RegExOutliers(ConditionalOutliers):
         """
         super(RegExOutliers, self).__init__()
         # Ensure that patterns is a list.
-        if not isinstance(patterns, list):
-            patterns = [patterns]
+        patterns = patterns if isinstance(patterns, list) else [patterns]
         # Set the predicate that is used to identify outliers. Distinguish
         # based on number of elements in the pattern list.
         if len(patterns) == 0:

--- a/openclean/profiling/pattern/base.py
+++ b/openclean/profiling/pattern/base.py
@@ -12,7 +12,7 @@ from abc import ABCMeta, abstractmethod
 from openclean.profiling.base import DistinctSetProfiler
 
 
-class Pattern(metaclass=ABCMeta):  # pragma: no cover
+class Pattern(metaclass=ABCMeta):
     """Interface for objects representing patterns, e.g., a regular expression,
     that was discovered by a pattern finder. Implementations maintain a
     representation of the pattern itself as well as any additional metadata
@@ -46,7 +46,7 @@ class Pattern(metaclass=ABCMeta):  # pragma: no cover
         -------
         openclean.function.value.base.ValueFunction
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
     def metadata(self):
@@ -64,7 +64,7 @@ class Pattern(metaclass=ABCMeta):  # pragma: no cover
         -------
         dict
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
     def pattern(self):
@@ -86,7 +86,7 @@ class Pattern(metaclass=ABCMeta):  # pragma: no cover
         -------
         dict
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
 
 class PatternFinder(DistinctSetProfiler, metaclass=ABCMeta):
@@ -95,7 +95,6 @@ class PatternFinder(DistinctSetProfiler, metaclass=ABCMeta):
     data frame) as their input. The result is a (list of) string(s) that each
     represent a regular expression.
     """
-
     def exec(self, values):
         """This method is executed when the pattern finder is used as part of a
         data profiler. It returns a list with dictionary serializations for the
@@ -130,4 +129,4 @@ class PatternFinder(DistinctSetProfiler, metaclass=ABCMeta):
         -------
         list(openclean.profiling.pattern.base.Pattern)
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover

--- a/openclean/version.py
+++ b/openclean/version.py
@@ -7,4 +7,4 @@
 
 """Version information for the openclean package."""
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas>=1.0.0
 scikit-learn
 jsonschema>=3.2.0
 histore==0.3.1
-flowserv-core==0.6.0
+flowserv-core>=0.8.0
 jellyfish
 refdata>=0.2.0
 scipy

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'scikit-learn',
     'jsonschema>=3.2.0',
     'histore==0.3.1',
-    'flowserv-core==0.6.0',
+    'flowserv-core>=0.8.0',
     'jellyfish',
     'refdata>=0.2.0',
     'scipy'

--- a/tests/.files/config/default.yaml
+++ b/tests/.files/config/default.yaml
@@ -1,0 +1,4 @@
+- image: test1
+  worker: docker
+- image: test2
+  worker: subprocess

--- a/tests/.files/config/pckg.json
+++ b/tests/.files/config/pckg.json
@@ -1,0 +1,6 @@
+[
+    {
+        "image": "test2",
+        "worker": "docker"
+    }
+]

--- a/tests/data/archive/test_data_archives.py
+++ b/tests/data/archive/test_data_archives.py
@@ -22,7 +22,7 @@ DF_2 = pd.DataFrame(data=[[1, 2], [5, 6]], columns=['A', 'B'])
 def test_archive_manager(tmpdir):
     """Test master data manager functionality."""
     # -- Setup ----------------------------------------------------------------
-    os.environ[config.ENV_MASTERDATA_DIR] = str(tmpdir)
+    os.environ[config.ENV_DATA_DIR] = str(tmpdir)
     # Create two new archive for a given dataset.
     masterdata.create('First', primary_key=['A'])
     masterdata.create('Second', primary_key=['A'])
@@ -50,4 +50,4 @@ def test_archive_manager(tmpdir):
     with pytest.raises(ValueError):
         masterdata.get('First')
     # -- Cleanup --------------------------------------------------------------
-    del os.environ[config.ENV_MASTERDATA_DIR]
+    del os.environ[config.ENV_DATA_DIR]

--- a/tests/profiling/constraints/test_functional_dependencies.py
+++ b/tests/profiling/constraints/test_functional_dependencies.py
@@ -20,3 +20,4 @@ def test_init_functional_dependency():
     assert fd.rhs == ['C', 'D']
     assert fd.lhs == fd.determinant
     assert fd.rhs == fd.dependant
+    assert str(fd) == '[{}] -> [{}]'.format(','.join(fd.lhs), ','.join(fd.rhs))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,15 +27,6 @@ def test_config_datadir():
     del os.environ[config.ENV_DATA_DIR]
 
 
-def test_config_masterdatadir():
-    """Test getting the default master data directory from the configuration
-    settings in the environment.
-    """
-    os.environ[config.ENV_MASTERDATA_DIR] = '/my/masterdir'
-    assert config.MASTERDATADIR() == '/my/masterdir'
-    del os.environ[config.ENV_MASTERDATA_DIR]
-
-
 @pytest.mark.parametrize(
     'value,result',
     [('a', 1), ('-34.5', 1), ('0', 1), ('1', 1), ('4', 4)]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,7 +55,11 @@ def test_config_workers():
     assert factory.config['test1']['worker'] == 'docker'
     assert factory.config['test2']['worker'] == 'docker'
     # By default the factory configuration is empty.
+    env = dict(os.environ)
     del os.environ[config.ENV_WORKERS]
     del os.environ['OPENCLEAN_WORKERS_TEST']
+    factory = config.WORKERS(var='OPENCLEAN_WORKERS_TEST', env=env)
+    assert factory.config['test1']['worker'] == 'docker'
+    assert factory.config['test2']['worker'] == 'docker'
     factory = config.WORKERS()
     assert factory.config == dict()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,11 @@ import pytest
 
 import openclean.config as config
 
+DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '.files')
+CONFIG_DIR = os.path.join(DIR, 'config')
+DEFAULT_WORKERS = os.path.join(CONFIG_DIR, 'default.yaml')
+PACKAGE_WORKERS = os.path.join(CONFIG_DIR, 'pckg.json')
+
 
 def test_config_datadir():
     """Test getting the default data directory from the configuration settings
@@ -42,3 +47,24 @@ def test_config_threads(value, result):
     os.environ[config.ENV_THREADS] = value
     assert config.THREADS() == result
     del os.environ[config.ENV_THREADS]
+
+
+def test_config_workers():
+    """Test getting the flowServ worker factory from files referenced by
+    ennvironment variables.
+    """
+    # Get the default configuration.
+    os.environ[config.ENV_WORKERS] = DEFAULT_WORKERS
+    factory = config.WORKERS()
+    assert factory.config['test1']['worker'] == 'docker'
+    assert factory.config['test2']['worker'] == 'subprocess'
+    # Overwrite configuration with package specific settings.
+    os.environ['OPENCLEAN_WORKERS_TEST'] = PACKAGE_WORKERS
+    factory = config.WORKERS(var='OPENCLEAN_WORKERS_TEST')
+    assert factory.config['test1']['worker'] == 'docker'
+    assert factory.config['test2']['worker'] == 'docker'
+    # By default the factory configuration is empty.
+    del os.environ[config.ENV_WORKERS]
+    del os.environ['OPENCLEAN_WORKERS_TEST']
+    factory = config.WORKERS()
+    assert factory.config == dict()


### PR DESCRIPTION
This PR introduces the following changes for openclean v0.1.1:

* Bump `flowserv-core` dependency to version `0.8.0` for better support of running applications that are not implemented in Python.
* Introduce environment variable *OPENCLEAN_WORKERS* to configure workers for `flowserv-core`.
* Replace environment variables *OPENCLEAN_METADATA_DIR* with *OPENCLEAN_DATADIR*.
