### PR TITLE
Fetch metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,8 @@
 * Multi-threading for `ValueFunction.apply()`.
 * Separate DBSCAN outlier class.
 * Move us-street name functions to `openclean-geo`.
+
+
+### 0.3.1 - 2021-03-30
+
+* Add optional version parameter when requesting metadata for a dataset version in `openclean.engine.dataset.DatasetHandle`.

--- a/openclean/engine/dataset.py
+++ b/openclean/engine/dataset.py
@@ -49,7 +49,7 @@ class DatasetHandle(metaclass=ABCMeta):
         self.is_sample = is_sample
         self._log = OperationLog(snapshots=store.snapshots())
 
-    def checkout(self, version: Optional[str] = None) -> pd.DataFrame:
+    def checkout(self, version: Optional[int] = None) -> pd.DataFrame:
         """Checkout a dataset snapshot.
 
         The optional identifier references a dataset snapshot via an operation
@@ -58,7 +58,7 @@ class DatasetHandle(metaclass=ABCMeta):
 
         Parameters
         ----------
-        version: str, default=None
+        version: int, default=None
             Identifier for the operation log entry that represents the the
             dataset version that is being checked out.
 
@@ -163,14 +163,20 @@ class DatasetHandle(metaclass=ABCMeta):
         """
         return list(self._log)
 
-    def metadata(self) -> MetadataStore:
+    def metadata(self, version: Optional[int] = None) -> MetadataStore:
         """Get metadata that is associated with the current dataset version.
+
+        Parameters
+        ----------
+        version: int, default=None
+            Identifier for the dataset version for which the metadata is
+            being fetched.
 
         Returns
         -------
         openclean.data.metadata.base.MetadataStore
         """
-        return self.store.metadata()
+        return self.store.metadata(version=version)
 
     def update(
         self, columns: Columns, func: FunctionHandle, args: Optional[Dict] = None,
@@ -229,7 +235,7 @@ class DatasetHandle(metaclass=ABCMeta):
         """
         return self._log.last_version()
 
-    def rollback(self, version: str) -> pd.DataFrame:
+    def rollback(self, version: int) -> pd.DataFrame:
         """Rollback all changes including the given dataset version.
 
         That is, we rollback all changes that occurred at and after the
@@ -246,7 +252,7 @@ class DatasetHandle(metaclass=ABCMeta):
 
         Parameters
         ----------
-        version: string
+        version: int
             Unique log entry version.
 
         Returns

--- a/openclean/profiling/constraints/ucc.py
+++ b/openclean/profiling/constraints/ucc.py
@@ -17,7 +17,7 @@ import pandas as pd
 from openclean.data.types import Columns
 
 
-class UniqueColumnCombinationFinder(metaclass=ABCMeta):  # pragma: no cover
+class UniqueColumnCombinationFinder(metaclass=ABCMeta):
     """Interface for operators that discover combinations of unique columns in
     a given data frame.
     """
@@ -36,4 +36,4 @@ class UniqueColumnCombinationFinder(metaclass=ABCMeta):  # pragma: no cover
         -------
         list
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover

--- a/openclean/profiling/pattern/base.py
+++ b/openclean/profiling/pattern/base.py
@@ -115,7 +115,7 @@ class PatternFinder(DistinctSetProfiler, metaclass=ABCMeta):
         return result
 
     @abstractmethod
-    def find(self, values):  # pragma: no cover
+    def find(self, values):
         """Discover patterns like regular expressions in a given sequence of
         (distinct) values. Returns a list of objects representing the
         discovered patterns.

--- a/openclean/version.py
+++ b/openclean/version.py
@@ -7,4 +7,4 @@
 
 """Version information for the openclean package."""
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/tests/profiling/constraints/test_ucc_finder.py
+++ b/tests/profiling/constraints/test_ucc_finder.py
@@ -1,0 +1,26 @@
+# This file is part of the Data Cleaning Library (openclean).
+#
+# Copyright (C) 2018-2021 New York University.
+#
+# openclean is released under the Revised BSD License. See file LICENSE for
+# full license details.
+
+"""Unit tests for the abstract unique column combination finder  base class."""
+
+from typing import List
+
+import pandas as pd
+
+from openclean.data.types import Columns
+from openclean.profiling.constraints.ucc import UniqueColumnCombinationFinder
+
+
+class UCCDummy(UniqueColumnCombinationFinder):
+    """Dummy implementation of the unique column combination finder."""
+    def run(self, df: pd.DataFrame) -> List[Columns]:
+        return df.columns
+
+
+def test_dummy_ucc_finder(employees):
+    """Test unique column combination finder."""
+    assert UCCDummy().run(employees) is not None


### PR DESCRIPTION
This PR addresses an issue with the `openclean.engine.dataset.DatasetHandle` that came up while fixing issue VIDA-NYU/openclean-notebook#24

* Add optional version parameter when requesting metadata for a dataset version in `openclean.engine.dataset.DatasetHandle`.
