### PR TITLE
Dev 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,9 @@
 ### 0.3.1 - 2021-03-30
 
 * Add optional version parameter when requesting metadata for a dataset version in `openclean.engine.dataset.DatasetHandle`.
+
+
+### 0.3.2 - 2021-04-06
+
+* Make checking out a committed dataset in the `openclean.data.archive.base.ArchiveStore` optional.
+* Enable cache refresh for cached datasets in `openclean.data.archive.cache.CachedDatastore`.

--- a/openclean/data/archive/base.py
+++ b/openclean/data/archive/base.py
@@ -70,11 +70,13 @@ class ArchiveStore(metaclass=ABCMeta):
         raise NotImplementedError()  # pragma: no cover
 
     @abstractmethod
-    def commit(self, df: pd.DataFrame, action: Optional[ActionHandle] = None) -> pd.DataFrame:
+    def commit(
+        self, df: pd.DataFrame, action: Optional[ActionHandle] = None,
+        checkout: Optional[bool] = False
+    ) -> pd.DataFrame:
         """Insert a new dataset snapshot.
 
-        Returns the inserted data frame (after potentially modifying the row
-        indexes) and the version identifier for the commited version.
+        Returns the inserted data frame with potentially modified row indexes.
 
         Parameters
         ----------
@@ -82,6 +84,12 @@ class ArchiveStore(metaclass=ABCMeta):
             Data frame containing the new dataset version that is being stored.
         action: openclean.data.archive.base.ActionHandle, default=None
             Optional handle of the action that created the new dataset version.
+        checkout: bool, default=False
+            Checkout the commited snapshot and return the result. This option
+            is required only if the row index of the given data frame has been
+            modified by the commit operation, i.e., if the index of the given
+            data frame contained non-integers, negative values, or duplicate
+            values.
 
         Returns
         -------

--- a/openclean/data/archive/histore.py
+++ b/openclean/data/archive/histore.py
@@ -63,9 +63,15 @@ class HISTOREDatastore(ArchiveStore):
         """
         return self.archive.checkout(version=version)
 
-    def commit(self, df: pd.DataFrame, action: Optional[ActionHandle] = None) -> pd.DataFrame:
-        """Insert a new version for a dataset. Returns the inserted data frame
-        (after potentially modifying the row indexes).
+    def commit(
+        self, df: pd.DataFrame, action: Optional[ActionHandle] = None,
+        checkout: Optional[bool] = False
+    ) -> pd.DataFrame:
+        """Insert a new version for a dataset.
+
+        Returns the inserted data frame. If the ``checkout`` flag is True the
+        commited dataset is checked out to account for possible changes to the
+        row index. If the flag is set to False the given data frame is returned.
 
         Parameters
         ----------
@@ -73,6 +79,12 @@ class HISTOREDatastore(ArchiveStore):
             Data frame containing the new dataset version that is being stored.
         action: openclean.data.archive.base.ActionHandle, default=None
             Optional handle of the action that created the new dataset version.
+        checkout: bool, default=False
+            Checkout the commited snapshot and return the result. This option
+            is required only if the row index of the given data frame has been
+            modified by the commit operation, i.e., if the index of the given
+            data frame contained non-integers, negative values, or duplicate
+            values.
 
         Returns
         -------
@@ -82,7 +94,7 @@ class HISTOREDatastore(ArchiveStore):
             doc=df,
             action=action.to_dict() if action is not None else None
         )
-        return self.archive.checkout(version=self._last_snapshot.version)
+        return self.archive.checkout(version=self._last_snapshot.version) if checkout else df
 
     def last_version(self) -> int:
         """Get a identifier for the last version of a dataset.

--- a/openclean/engine/library.py
+++ b/openclean/engine/library.py
@@ -18,7 +18,7 @@ dedicated methods to access the object stores for different types.
 """
 
 from __future__ import annotations
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, Union
 
 from openclean.data.mapping import Mapping
 from openclean.data.store.mem import VolatileDataStore
@@ -69,8 +69,8 @@ class ObjectLibrary(object):
     def eval(
         self, name: Optional[str] = None, namespace: Optional[str] = None,
         label: Optional[str] = None, description: Optional[str] = None,
-        columns: Optional[int] = None, outputs: Optional[int] = None,
-        parameters: Optional[List[Parameter]] = None
+        columns: Optional[int] = None, collabels: Optional[Union[str, List[str]]] = None,
+        outputs: Optional[int] = None, parameters: Optional[List[Parameter]] = None
     ) -> Callable:
         """Decorator that adds a new function to the registered set of data
         frame transformers.
@@ -93,6 +93,9 @@ class ObjectLibrary(object):
             each column plus arguments for any additional parameter. The
             column values will be the first arguments that are passed to the
             registered function.
+        collabels: string or list of string, default=None
+            Display labels for the nput columns. If given the number of values
+            has to match the ``columns`` value.
         outputs: int, default=None
             Defines the number of scalar output values that the registered
             function returns. By default it is assumed that the function will
@@ -118,6 +121,7 @@ class ObjectLibrary(object):
                 label=label,
                 description=description,
                 columns=columns,
+                collabels=collabels,
                 outputs=outputs,
                 parameters=parameters
             )

--- a/openclean/version.py
+++ b/openclean/version.py
@@ -7,4 +7,4 @@
 
 """Version information for the openclean package."""
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/tests/data/archive/test_cached_datastore.py
+++ b/tests/data/archive/test_cached_datastore.py
@@ -24,24 +24,30 @@ def test_cache_dataframe(dataset, store):
     """Test maintaining the last dataset in the cache."""
     cached_store = CachedDatastore(datastore=store)
     # -- First snapshot -------------------------------------------------------
-    df = cached_store.commit(df=dataset)
-    assert df.shape == (2, 3)
+    df_1 = cached_store.commit(df=dataset)
+    assert df_1.shape == (2, 3)
     assert cached_store._cache is not None
     assert cached_store._cache.df.shape == (2, 3)
     assert cached_store._cache.version == 0
     assert cached_store.last_version() == 0
-    df = cached_store.checkout()
-    assert df.shape == (2, 3)
-    df = df[df['A'] == 1]
+    df_1 = cached_store.checkout()
+    assert df_1.shape == (2, 3)
+    df_2 = df_1[df_1['A'] == 1]
     # -- Second snapshot ------------------------------------------------------
-    df = cached_store.commit(df=df)
-    assert df.shape == (1, 3)
+    df_2 = cached_store.commit(df=df_2)
+    assert df_2.shape == (1, 3)
     assert cached_store._cache.df.shape == (1, 3)
     assert cached_store._cache.version == 1
     assert len(cached_store.snapshots()) == 2
     # -- Checkout first snapshot ----------------------------------------------
-    df = cached_store.checkout(version=0)
-    assert df.shape == (2, 3)
+    df_1 = cached_store.checkout(version=0)
+    assert df_1.shape == (2, 3)
+    assert cached_store._cache.df.shape == (2, 3)
+    assert cached_store._cache.version == 0
+    # -- Refresh cache --------------------------------------------------------
+    cached_store._cache.df = df_2
+    df_1 = cached_store.checkout(version=0, no_cache=True)
+    assert df_1.shape == (2, 3)
     assert cached_store._cache.df.shape == (2, 3)
     assert cached_store._cache.version == 0
 

--- a/tests/engine/object/test_function_objects.py
+++ b/tests/engine/object/test_function_objects.py
@@ -7,6 +7,8 @@
 
 """Unit tests for (de-)serialization of function handles."""
 
+import pytest
+
 from openclean.engine.object.function import FunctionHandle, FunctionFactory
 from openclean.engine.object.function import Int
 
@@ -27,6 +29,7 @@ def test_serialize_function():
     assert f.label is None
     assert f.description is None
     assert f.columns == 1
+    assert f.collabels == ['n']
     assert f.outputs == 1
     assert f.parameters == []
     f.func(0.1)
@@ -38,6 +41,7 @@ def test_serialize_function():
         label='My Name',
         description='Just a test',
         columns=2,
+        collabels=['a', 'b'],
         outputs=3,
         parameters=[Int('sleep')]
     )
@@ -48,7 +52,21 @@ def test_serialize_function():
     assert f.label == 'My Name'
     assert f.description == 'Just a test'
     assert f.columns == 2
+    assert f.collabels == ['a', 'b']
     assert f.outputs == 3
     assert len(f.parameters) == 1
     assert f.parameters[0].is_int()
     f.func(0.1)
+    # Error case
+    with pytest.raises(ValueError):
+        FunctionHandle(
+            func=my_func,
+            name='myname',
+            namespace='mynamespace',
+            label='My Name',
+            description='Just a test',
+            columns=2,
+            collabels=['a'],
+            outputs=3,
+            parameters=[Int('sleep')]
+        )


### PR DESCRIPTION
This PR contains the following changes:

* Make checking out a committed dataset in the `openclean.data.archive.base.ArchiveStore` optional.
* Enable cache refresh for cached datasets in `openclean.data.archive.cache.CachedDatastore`.
